### PR TITLE
fix(install): resolve spawn ENOENT for npm on Windows

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -8,7 +8,11 @@ import { spawnSync } from "child_process";
 import { readFileSync, writeFileSync } from "fs";
 
 function runCommand(command, args, options) {
-  const result = spawnSync(command, args, options);
+  const result = spawnSync(command, args, {
+    ...options,
+    shell: true,
+    encoding: "utf-8"
+  });
 
   if (result.error) {
     console.error(
@@ -125,7 +129,7 @@ writeFileSync(packageJsonAbsPath, JSON.stringify(packageJson, null, 2));
 StatusMessages.FILES_COPIED(projectDirectoryAbsPath);
 
 StatusMessages.NPM_INSTALL();
-const npmInstallResult = spawnSync("npm", ["install"], {
+const npmInstallResult = runCommand("npm", ["install"], {
   stdio: "inherit",
   cwd: projectDirectoryAbsPath,
 });
@@ -136,7 +140,7 @@ if (npmInstallResult.error) {
 StatusMessages.PACKAGES_INSTALLED();
 
 if (IS_WINDOWS_PLATFORM) {
-  runCommand("del", [".git"], {
+  runCommand("del", ["/q", ".git"], {
     stdio: "ignore",
     cwd: projectDirectoryAbsPath,
   });


### PR DESCRIPTION
## PR: Install script fixes (shell, encoding, Windows)

### Summary

Updates `bin/install.js` so subprocess execution is consistent and Windows `.git` removal is non-interactive.

### Issue

On Windows, the installer failed at "Installing packages ..." with `spawnSync npm ENOENT` because `spawnSync("npm", ["install"], ...)` was used without `shell: true`. Without a shell, Node resolves the executable from `PATH` in a way that doesn’t match how npm is typically installed on Windows (e.g. via npm.cmd or the shell’s PATH), so the process couldn’t find `npm`.

**Error:**
```bash
Copying files ...
Files copied to C:\Container\documentation\consolidate-md-files ✔
Installing packages ...
Error installing packages: Error: spawnSync npm ENOENT
    at Object.spawnSync (node:internal/child_process:1120:20)
    at spawnSync (node:child_process:911:24)
    at file:///C:/Users/.../create-ts-cli-app/bin/install.js:128:26
    ...
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawnSync npm',
  path: 'npm',
  spawnargs: [ 'install' ]
}
```

### Changes

1. **`runCommand` – spawn options**
  - All `spawnSync` calls from `runCommand` now use merged options with:
    - `shell: true` — run commands in a shell (needed for Windows and PATH resolution).
    - `encoding: "utf-8"` — consistent string output for stderr/stdout.
2. **`npm install`**
  - Replaced direct `spawnSync("npm", ["install"], ...)` with `runCommand("npm", ["install"], ...)` so `npm install` uses the same shell + encoding and the same error handling/exit behavior as other commands.
3. **Windows `.git` removal**
  - `del .git` changed to `del /q .git` so deletion is non-interactive (`/q` = quiet, no confirmation prompt).

### Rationale

- **Shell**: Ensures `npm` and other commands run correctly on Windows and with proper PATH.
- **Encoding**: Avoids encoding issues when reading/writing subprocess output.
- **`/q`**: Prevents the install from hanging on Windows when removing the cloned `.git` directory.

